### PR TITLE
Fix cloudfront path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React, { Component} from "react";
 import PropTypes from 'prop-types';
 
-const universalViewerUrl = "https://dptsn6y11mgr6.cloudfront.net/universalviewer/index.html"
+const universalViewerUrl = "/universalviewer/index.html"
 class ImageViewer extends Component{
   render(){
     return(


### PR DESCRIPTION
There is a cors issue with loading the example application using the react component.  This temporarily fixes it.  We will still need to find a way to get the correct url for the hosted version of universalviewer.  


