### PR TITLE
Change default sidebar to display 'info' instead of 'canvas'

### DIFF
--- a/src/components/miradorrenderer/config/index.js
+++ b/src/components/miradorrenderer/config/index.js
@@ -32,7 +32,7 @@ export const buildConfig = (id, location, themeColor = '#blue') => {
       allowMaximize: false,
       hideWindowTitle: hideWindowTitle,
       sideBarOpenByDefault: sideBarOpenByDefault,
-      defaultSideBarPanel: 'canvas',
+      defaultSideBarPanel: 'info',
       views: [
         { key: 'single' },
         { key: 'book' },


### PR DESCRIPTION
Change so adding the query parameter `&sidebar=true` will display the the about this item information instead of the list of canvases.